### PR TITLE
Minor update

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -70,7 +70,12 @@ To use baskio to build an image, an Openstack cluster is required.`,
 				log.Fatalln(err)
 			}
 
+			build.SaveImageIDToFile(imgID)
+			if err != nil {
+				log.Fatalln(err)
+			}
 			fmt.Println(imgID)
+
 		},
 	}
 

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -141,3 +141,15 @@ func RetrieveNewImageID() (string, error) {
 
 	return i, nil
 }
+
+// SaveImageIDToFile exports the image ID to a file so that it can be read later by the scan system - this will generally be used by the gitHub action.
+func SaveImageIDToFile(imgID string) error {
+	f, err := os.Create("/tmp/imgid.out")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	f.Write([]byte(imgID))
+
+	return nil
+}

--- a/pkg/openstack/config.go
+++ b/pkg/openstack/config.go
@@ -188,7 +188,6 @@ func (p *PackerBuildConfig) GenerateVariablesFile(buildGitDir string) {
 		log.Fatalln(err)
 	}
 
-	fmt.Println(string(configContent))
 	err = os.WriteFile(outputFile, configContent, 0644)
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
This update removed some redundant printing and writes out the image Id to a file in /tmp which can be used by automated procedures as required.