### PR TITLE
New option for specifying branch to clone from image builder repo

### DIFF
--- a/baski-example.yaml
+++ b/baski-example.yaml
@@ -53,6 +53,8 @@ build:
   image-prefix: "kube"
   # The repo to use for image building. This will default to the main image builder repo but can be updated if additional functionality is required in a fork.
   image-repo: "https://github.com/kubernetes-sigs/image-builder.git"
+  # The branch to checkout from the image repo
+  image-repo-branch: "main"
   # The crictl version.
   crictl-version: "1.26.0"
   # The CNI version.

--- a/pkg/cmd/build/process.go
+++ b/pkg/cmd/build/process.go
@@ -17,16 +17,17 @@ limitations under the License.
 package build
 
 import (
-	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
-	gitRepo "github.com/eschercloudai/baski/pkg/git"
-	systemUtils "github.com/eschercloudai/baski/pkg/system"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/google/uuid"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
+	gitRepo "github.com/eschercloudai/baski/pkg/git"
+	systemUtils "github.com/eschercloudai/baski/pkg/system"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/uuid"
 )
 
 // CreateRepoDirectory create the random directory where the Image repo will be cloned into.
@@ -49,8 +50,7 @@ func CreateRepoDirectory() string {
 
 // FetchBuildRepo simply pulls the contents of the imageRepo to the specified path
 func FetchBuildRepo(path string, o *flags.BuildOptions) {
-	var branch plumbing.ReferenceName
-	branch = plumbing.Master
+	branch := plumbing.ReferenceName("refs/heads/" + o.ImageRepoBranch)
 	imageRepo := o.ImageRepo
 
 	//FIXME: This check is in place until the security branch in this repo go upstream.
@@ -63,7 +63,7 @@ func FetchBuildRepo(path string, o *flags.BuildOptions) {
 
 	_, err := gitRepo.GitClone(imageRepo, path, branch)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Error cloning repo: %s", err)
 	}
 }
 

--- a/pkg/cmd/util/flags/build.go
+++ b/pkg/cmd/util/flags/build.go
@@ -2,9 +2,10 @@ package flags
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 type BuildOptions struct {
@@ -15,6 +16,7 @@ type BuildOptions struct {
 	BuildOS                 string
 	ImagePrefix             string
 	ImageRepo               string
+	ImageRepoBranch         string
 	CrictlVersion           string
 	CniVersion              string
 	KubeVersion             string
@@ -39,6 +41,7 @@ func (o *BuildOptions) SetOptionsFromViper() {
 	o.BuildOS = viper.GetString(fmt.Sprintf("%s.build-os", viperBuildPrefix))
 	o.ImagePrefix = viper.GetString(fmt.Sprintf("%s.image-prefix", viperBuildPrefix))
 	o.ImageRepo = viper.GetString(fmt.Sprintf("%s.image-repo", viperBuildPrefix))
+	o.ImageRepoBranch = viper.GetString(fmt.Sprintf("%s.image-repo-branch", viperBuildPrefix))
 	o.CrictlVersion = viper.GetString(fmt.Sprintf("%s.crictl-version", viperBuildPrefix))
 	o.CniVersion = viper.GetString(fmt.Sprintf("%s.cni-version", viperBuildPrefix))
 	o.KubeVersion = viper.GetString(fmt.Sprintf("%s.kubernetes-version", viperBuildPrefix))
@@ -64,6 +67,7 @@ func (o *BuildOptions) AddFlags(cmd *cobra.Command, imageBuilderRepo string) {
 	StringVarWithViper(cmd, &o.BuildOS, viperBuildPrefix, "build-os", "ubuntu-2204", "This is the target os to build. Valid values are currently: ubuntu-2004 and ubuntu-2204")
 	StringVarWithViper(cmd, &o.ImagePrefix, viperBuildPrefix, "image-prefix", "kube", "This will prefix the image with the value provided. Defaults to 'kube' producing an image name of kube-yymmdd-xxxxxxxx")
 	StringVarWithViper(cmd, &o.ImageRepo, viperBuildPrefix, "image-repo", strings.Join([]string{imageBuilderRepo, "git"}, "."), "The imageRepo from which the image builder should be deployed")
+	StringVarWithViper(cmd, &o.ImageRepoBranch, viperBuildPrefix, "image-repo-branch", "main", "The branch to checkout from the cloned imageRepo")
 	StringVarWithViper(cmd, &o.CniVersion, viperBuildPrefix, "cni-version", "1.2.0", "The CNI plugins version to include to the built image")
 	StringVarWithViper(cmd, &o.CrictlVersion, viperBuildPrefix, "crictl-version", "1.25.0", "The crictl-tools version to add to the built image")
 	StringVarWithViper(cmd, &o.KubeVersion, viperBuildPrefix, "kubernetes-version", "1.25.3", "The Kubernetes version to add to the built image")

--- a/pkg/git/gitrepo.go
+++ b/pkg/git/gitrepo.go
@@ -18,11 +18,12 @@ package gitRepo
 
 import (
 	"context"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"log"
 	"os"
 	"os/signal"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // GitClone will clone a designated repo.


### PR DESCRIPTION
Introduce a new option which lets the client configure which branch to checkout from the image builder repo.  Defaults to 'main'.