### PR TITLE
feat: enabled ability to set instance type for scan

### DIFF
--- a/pkg/cmd/util/flags/scan.go
+++ b/pkg/cmd/util/flags/scan.go
@@ -25,6 +25,12 @@ func (o *ScanOptions) SetOptionsFromViper() {
 	o.OpenStackFlags.SetOptionsFromViper()
 	o.S3Flags.SetOptionsFromViper()
 
+	// We can override the value of the instance at the scan level
+	// This isn't available in the flags as it's already a flag that's available. This is viper only.
+	instance := viper.GetString(fmt.Sprintf("%s.flavor-name", viperScanPrefix))
+	if instance != "" {
+		o.FlavorName = instance
+	}
 	o.AddPause = viper.GetBool(fmt.Sprintf("%s.add-pause", viperOpenStackPrefix))
 	o.ImageID = viper.GetString(fmt.Sprintf("%s.image-id", viperScanPrefix))
 	o.AutoDeleteImage = viper.GetBool(fmt.Sprintf("%s.auto-delete-image", viperScanPrefix))


### PR DESCRIPTION
Enabled the ability to set the instance at the scan level rather than using the instance that was used for building. This allows a non-GPU instance to do the scan.