### PR TITLE
Align with upstream repo / packaging changes

### DIFF
--- a/baski-example.yaml
+++ b/baski-example.yaml
@@ -59,8 +59,12 @@ build:
   crictl-version: "1.26.0"
   # The CNI version.
   cni-version: "1.2.0"
+  # The specific version of the CNI Debian package ('kubernetes-cni') to install
+  cni-deb-version: "1.2.0-2.1"
   # The Kubernetes version.
-  kubernetes-version: "1.26.3"
+  kubernetes-version: "1.28.2"
+  # The specific version of the Kubernetes Debian packages ('kubeadm', 'kubelet') to install  
+  kubernetes-deb-version: "1.28.2-1.1"
   # Any additional debs to install. Currently, Baski only supports ubuntu and flatcar and this will only work with Ubuntu
   extra-debs: "nfs-common"
   # Whether to add Trivy into the image.

--- a/pkg/cmd/util/flags/build.go
+++ b/pkg/cmd/util/flags/build.go
@@ -19,7 +19,10 @@ type BuildOptions struct {
 	ImageRepoBranch         string
 	CrictlVersion           string
 	CniVersion              string
+	CniDebVersion           string
 	KubeVersion             string
+	KubeRpmVersion          string
+	KubeDebVersion          string
 	ExtraDebs               string
 	AdditionalImages        []string
 	AddFalco                bool
@@ -44,7 +47,10 @@ func (o *BuildOptions) SetOptionsFromViper() {
 	o.ImageRepoBranch = viper.GetString(fmt.Sprintf("%s.image-repo-branch", viperBuildPrefix))
 	o.CrictlVersion = viper.GetString(fmt.Sprintf("%s.crictl-version", viperBuildPrefix))
 	o.CniVersion = viper.GetString(fmt.Sprintf("%s.cni-version", viperBuildPrefix))
+	o.CniDebVersion = viper.GetString(fmt.Sprintf("%s.cni-deb-version", viperBuildPrefix))
 	o.KubeVersion = viper.GetString(fmt.Sprintf("%s.kubernetes-version", viperBuildPrefix))
+	o.KubeDebVersion = viper.GetString(fmt.Sprintf("%s.kubernetes-deb-version", viperBuildPrefix))
+	o.KubeRpmVersion = viper.GetString(fmt.Sprintf("%s.kubernetes-rpm-version", viperBuildPrefix))
 	o.ExtraDebs = viper.GetString(fmt.Sprintf("%s.extra-debs", viperBuildPrefix))
 	o.AdditionalImages = viper.GetStringSlice(fmt.Sprintf("%s.additional-images", viperBuildPrefix))
 	o.AddFalco = viper.GetBool(fmt.Sprintf("%s.add-falco", viperBuildPrefix))

--- a/pkg/openstack/config.go
+++ b/pkg/openstack/config.go
@@ -19,14 +19,16 @@ package ostack
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/eschercloudai/baski/pkg/cmd/util/flags"
 
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
@@ -117,6 +119,12 @@ func (c *OpenstackClouds) SetOpenstackEnvs(cloudName string) {
 	}
 }
 
+// Extract Kubernetes series with the assumption we want vX.XX
+func truncateVersion(version string) string {
+	re := regexp.MustCompile(`v\d+\.\d+`)
+	return re.FindString(version)
+}
+
 // InitPackerConfig takes the application inputs and converts it into a PackerBuildConfig.
 func InitPackerConfig(o *flags.BuildOptions) *PackerBuildConfig {
 	buildConfig := &PackerBuildConfig{
@@ -127,13 +135,13 @@ func InitPackerConfig(o *flags.BuildOptions) *PackerBuildConfig {
 		UseFloatingIp:        strconv.FormatBool(o.UseFloatingIP),
 		FloatingIpNetwork:    o.FloatingIPNetworkName,
 		CniVersion:           "v" + o.CniVersion,
-		CniDebVersion:        o.CniVersion + "-00",
+		CniDebVersion:        o.CniDebVersion,
 		CrictlVersion:        o.CrictlVersion,
 		ImageVisibility:      o.ImageVisibility,
 		KubernetesSemver:     "v" + o.KubeVersion,
-		KubernetesSeries:     "v" + o.KubeVersion,
-		KubernetesRpmVersion: o.KubeVersion + "-0",
-		KubernetesDebVersion: o.KubeVersion + "-00",
+		KubernetesSeries:     truncateVersion("v" + o.KubeVersion),
+		KubernetesRpmVersion: o.KubeRpmVersion,
+		KubernetesDebVersion: o.KubeDebVersion,
 		ExtraDebs:            o.ExtraDebs,
 		ImageDiskFormat:      o.ImageDiskFormat,
 		VolumeType:           o.VolumeType,


### PR DESCRIPTION
With the upstream changes outlined in [this page](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate), Baski needs to be updated to handle a wider range of combinations across the Kubernetes version and series, the CNI version, and the specific dpkg or RPM suffix.