### PR TITLE
patch: moving to latest container scanner

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
     steps:
       - name: Build Local Baski Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-baski
         with:
@@ -49,7 +49,13 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski"
           add-latest-tag: false
           publish-image: false
           cosign-private-key: ${{secrets.COSIGN_KEY}}
@@ -57,7 +63,7 @@ jobs:
           cosign-tlog: false
           dockerfile-path: docker/baski
       - name: Build Local Baski Server Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-server
         with:
@@ -66,7 +72,13 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski-server
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski-server"
           add-latest-tag: false
           publish-image: false
           cosign-private-key: ${{secrets.COSIGN_KEY}}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -43,7 +43,7 @@ jobs:
       id-token: write
     steps:
       - name: Build Local Baski Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-baski
         with:
@@ -52,15 +52,20 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
-          add-latest-tag: false
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski"
           publish-image: false
           cosign-private-key: ${{secrets.COSIGN_KEY}}
           cosign-password: ${{secrets.COSIGN_PASSWORD}}
           cosign-tlog: false
           dockerfile-path: docker/baski
       - name: Build Local Baski Server Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-server
         with:
@@ -69,7 +74,13 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski-server
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski-server"
           add-latest-tag: false
           publish-image: false
           cosign-private-key: ${{secrets.COSIGN_KEY}}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Build Baski Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-baski
         with:
@@ -51,7 +51,13 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski"
           add-latest-tag: true
           publish-image: true
           cosign-private-key: ${{secrets.COSIGN_KEY}}
@@ -59,7 +65,7 @@ jobs:
           cosign-tlog: true
           dockerfile-path: docker/baski
       - name: Build Baski Server Image
-        uses: eschercloudai/container-security-action@v0.0.1-beta.3
+        uses: eschercloudai/container-security-action@v0.0.1
         if: github.event_name != 'pull_request'
         id: build-and-scan-server
         with:
@@ -68,7 +74,13 @@ jobs:
           repo-password: ${{ secrets.GITHUB_TOKEN }}
           image-name: baski-server
           image-tag: ${{ github.ref_name }}
-          min-severity: critical
+          check-severity: CRITICAL
+          trivyignore-from-s3: true
+          aws-endpoint: "https://nl1.eschercloud.com:6780"
+          aws-access-key: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-key: ${{secrets.AWS_SECRET_KEY}}
+          s3-bucket: "trivyignores"
+          s3-path: "baski-server"
           add-latest-tag: true
           publish-image: true
           cosign-private-key: ${{secrets.COSIGN_KEY}}

--- a/baski-example.yaml
+++ b/baski-example.yaml
@@ -147,16 +147,3 @@ sign:
   # If you would like to validate an image signing, this allows you to put the digest in and validate the image.
   # This will be deprecated and then removed soon to make way for fetching the digest from the metadata of the image where it is currently stored.
   digest: ""
-
-# Publish stage options - this is deprecated and will be rwqorked soon to no longer have reliance on GitHub pages.
-# It will instead generate the HTML/Js so that the user can review the results locally and, if they wish, add it to an accessible website/server.
-# It is recommended you do not use this stage for now.
-publish:
-  image-id: ""
-  github:
-    user: "some-user"
-    account: "some-account"
-    project: "some-project"
-    token: "123456789"
-    pages-branch: ""
-  #results-file: "/tmp/results.json" # Not currently used


### PR DESCRIPTION
# What's Changed
Just flipping the container scanner over to the new one

# Why is it required?
Because it's better

# PR checklist
- [x] Run tests locally
- [ ] Updated Readme
- [ ] Updated Changelog
